### PR TITLE
fix typos

### DIFF
--- a/content/post/SICP-Solution-Exercise-1-13.md
+++ b/content/post/SICP-Solution-Exercise-1-13.md
@@ -11,13 +11,13 @@ type: posts
 
 The first step is to start from the definition of Fibonaci:
 
-$$\text{Fib}(n)\;=\;\text{Fib}(n-1)\;+\;\text{Fib}(n-2)$$
+$$\text{Fib}(n) = \text{Fib}(n-1) + \text{Fib}(n-2)$$
 
 And insert the definition we want to prove, ${\text{Fib}(n)}={(\varphi^n-\psi^n)/\sqrt5}$, on both side:
 
-$$\frac{(\varphi^n-\psi^n)}{\sqrt5}\;=\frac{(\varphi^{n-1}-\psi^{n-1})}{\sqrt5}\;+\frac{(\varphi^{n-2}-\psi^{n-2})}{\sqrt5}$$
+$$\frac{(\varphi^n-\psi^n)}{\sqrt5} =\frac{(\varphi^{n-1}-\psi^{n-1})}{\sqrt5} +\frac{(\varphi^{n-2}-\psi^{n-2})}{\sqrt5}$$
 
-$$\varphi^n-\psi^n=\varphi^{n-1}-\psi^{n-1}\;+\varphi^{n-2}-\psi^{n-2}$$
+$$\varphi^n-\psi^n=\varphi^{n-1}-\psi^{n-1} +\varphi^{n-2}-\psi^{n-2}$$
 
 $$\varphi^n-\psi^n=\frac{\varphi^n}\varphi-\frac{\psi^n}\psi+\frac{\varphi^n}{\varphi^2}-\frac{\psi^n}{\psi^2}$$
 

--- a/content/post/SICP-Solution-Exercise-1-14.md
+++ b/content/post/SICP-Solution-Exercise-1-14.md
@@ -193,8 +193,8 @@ edge [penwidth=.1, arrowsize=0.5];
 
 Let's break it down:
 
-- There are 4 green nodes for `(c x 2)` corresponding to how many time you can subtract a dime from 12, plus one.
-- Then for each of the green node, there is the option of using only dime, which is the case that we looked at first.
+- There are 4 green nodes for `(c x 2)` corresponding to how many time you can subtract a nickel from 12, plus one.
+- Then for each of the green node, there is the option of using only pennies, which is the case that we looked at first.
 
 For an amount $n$, there is at most $Floor\left(\frac n5\right)+1$ times you can subtract nickels from it before reaching zero or a negative value. By simplifying a little and ignoring the floor that won't impact a lot the result when the number grows larger, we can split the number of calls to `cc` and compute $T(n,2)$:
 

--- a/content/post/SICP-Solution-Exercise-1-14.md
+++ b/content/post/SICP-Solution-Exercise-1-14.md
@@ -203,42 +203,42 @@ For an amount $n$, there is at most $Floor\left(\frac n5\right)+1$ times you can
 
 We can rewrite this as an equation and simplify it:
 
-$$T(n,2)\;=\frac n5+1+\;\sum\_{i=0}^{n/5}T(n-5i,1)$$
+$$T(n,2) =\frac n5+1+ \sum\_{i=0}^{n/5}T(n-5i,1)$$
 
-$$T(n,2)\;=\frac n5+1+\;\sum\_{i=0}^{n/5}(2n-10i+1)$$
+$$T(n,2) =\frac n5+1+ \sum\_{i=0}^{n/5}(2n-10i+1)$$
 
-$$T(n,2)\;=\frac n5+1+\frac{2n^2}5+\frac n5-10\;\sum\_{i=0}^{n/5}i$$
+$$T(n,2) =\frac n5+1+\frac{2n^2}5+\frac n5-10 \sum\_{i=0}^{n/5}i$$
 
-$$T(n,2)\;=\frac n5+1+\frac{2n^2}5+\frac n5-10\frac{{\displaystyle\frac n5}\left({\displaystyle\frac n5}+1\right)}2$$
+$$T(n,2) =\frac n5+1+\frac{2n^2}5+\frac n5-10\frac{{\displaystyle\frac n5}\left({\displaystyle\frac n5}+1\right)}2$$
 
-$$T(n,2)\;=\frac{2n}5+\frac{2n^2}5-\frac{n^2}5+n+1$$
+$$T(n,2) =\frac{2n}5+\frac{2n^2}5-\frac{n^2}5+n+1$$
 
 Very interestingly, it is possible to define a function that gives the exact number of steps for a given number $n$:
 
-$$T(n,2)\;=\frac{n^2+7n}5+1$$
+$$T(n,2) =\frac{n^2+7n}5+1$$
 
 Which means that for two type of coins, the orders of growth of number of steps is:
 
-$$T(n,2)\;=\mathrm\Theta(n^2)$$
+$$T(n,2) =\mathrm\Theta(n^2)$$
 
 For $T(n,3)$:
 
-$$T(n,3)\;=\frac n{10}+1+\;\sum\_{i=0}^{n/10}T(n-10i,2)$$
+$$T(n,3) =\frac n{10}+1+ \sum\_{i=0}^{n/10}T(n-10i,2)$$
 
 if you take the trouble to expand the equation, you will find that:
 
-$$T(n,3)\;=\mathrm\Theta(n^3)$$
+$$T(n,3) =\mathrm\Theta(n^3)$$
 
 by continuing to apply the formulas:
 
-$$T(n,3)\;=\frac n{10}+1+\;\sum\_{i=0}^{n/10}T(n-10i,1)$$
+$$T(n,3) =\frac n{10}+1+ \sum\_{i=0}^{n/10}T(n-10i,1)$$
 
-$$T(n,4)\;=\frac n{25}+1+\;\sum\_{i=0}^{n/25}T(n-25i,1)$$
+$$T(n,4) =\frac n{25}+1+ \sum\_{i=0}^{n/25}T(n-25i,1)$$
 
-$$T(n,5)\;=\frac n{50}+1+\;\sum\_{i=0}^{n/50}T(n-50i,1)$$
+$$T(n,5) =\frac n{50}+1+ \sum\_{i=0}^{n/50}T(n-50i,1)$$
 
 By doing all the expansion you find that the orders of growth of number of steps is:
 
-$$T(n,5)\;=\mathrm\Theta(n^5)$$
+$$T(n,5) =\mathrm\Theta(n^5)$$
 
 Overall, this is not only a very slow process, it is also a very inefficient way to implement this computation, because of all the repetitions. You can have a look at the solution for this exercice by Sarabander [here](https://github.com/sarabander/p2pu-sicp/blob/master/1.2/Ex1.14.scm) to see how to implement the solution in only $n^2$.

--- a/content/post/SICP-Solution-Exercise-1-15.md
+++ b/content/post/SICP-Solution-Exercise-1-15.md
@@ -7,7 +7,7 @@ type: posts
 
 **Exercise 1.15:** The sine of an angle (specified in radians) can be computed by making use of the approximation ${\sin x\approx x}$ if $x$ is sufficiently small, and the trigonometric identity
 
-$$\sin\;x\;=\;3\;\sin\frac x3-4\;\sin^3\frac x3$$
+$$\sin x = 3 \sin\frac x3-4 \sin^3\frac x3$$
 
 to reduce the size of the argument of sin. (For purposes of this exercise an angle is considered “sufficiently small” if its magnitude is not greater than 0.1 radians.) These ideas are incorporated in the following procedures:
 

--- a/content/post/SICP-Solution-Exercise-1-19.md
+++ b/content/post/SICP-Solution-Exercise-1-19.md
@@ -35,15 +35,15 @@ type: posts
 
 To solve this problem, it is necessary expand $T\_{pq}\left(T\_{pq}(a,b)\right)$ and see if we can refactor it:
 
-$$T\_{pq}(a,b)=(bq+aq+ap,\;bp+aq)$$
+$$T\_{pq}(a,b)=(bq+aq+ap, bp+aq)$$
 
-$$T\_{pq}\left(T\_{pq}(a,b)\right)=(\left(bp+aq\right)q+\left(bq+aq+ap\right)q+\left(bq+aq+ap\right)p,\;\left(\;bp+aq\right)p+\left(bq+aq+ap\right)q)$$
+$$T\_{pq}\left(T\_{pq}(a,b)\right)=(\left(bp+aq\right)q+\left(bq+aq+ap\right)q+\left(bq+aq+ap\right)p, \left( bp+aq\right)p+\left(bq+aq+ap\right)q)$$
 
-$$T\_{pq}\left(T\_{pq}(a,b)\right)=(bpq+aq^2+bq^2+aq^2+aqp+bqp+aqp+ap^2,\;bp^2+aqp+bq^2+aq^2+aqp)$$
+$$T\_{pq}\left(T\_{pq}(a,b)\right)=(bpq+aq^2+bq^2+aq^2+aqp+bqp+aqp+ap^2, bp^2+aqp+bq^2+aq^2+aqp)$$
 
 Which can be rewritten as:
 
-$$T\_{pq}\left(T\_{pq}(a,b)\right)=(b(2qp+q^2)+a(q^2+p^2)+a(2qp+q^2),\;b(p^2+q^2)+a(2qp+q^2))=T\_{p'q'}$$
+$$T\_{pq}\left(T\_{pq}(a,b)\right)=(b(2qp+q^2)+a(q^2+p^2)+a(2qp+q^2), b(p^2+q^2)+a(2qp+q^2))=T\_{p'q'}$$
 
 $$p'=p^2+q^2$$
 

--- a/content/post/SICP-Solution-Exercise-1-24.md
+++ b/content/post/SICP-Solution-Exercise-1-24.md
@@ -5,7 +5,7 @@ draft: false
 type: posts
 ---
 
-**Exercise 1.24:** Modify the `timed-prime-test` procedure of Exercise 1.22 to use `fast-prime?` (the Fermat method), and test each of the 12 primes you found in that exercise. Since the Fermat test has ${\mathrm\Theta(\log\;n)}$ growth, how would you expect the time to test primes near 1,000,000 to compare with the time needed to test primes near 1000? Do your data bear this out? Can you explain any discrepancy you find?
+**Exercise 1.24:** Modify the `timed-prime-test` procedure of Exercise 1.22 to use `fast-prime?` (the Fermat method), and test each of the 12 primes you found in that exercise. Since the Fermat test has ${\mathrm\Theta(\log n)}$ growth, how would you expect the time to test primes near 1,000,000 to compare with the time needed to test primes near 1000? Do your data bear this out? Can you explain any discrepancy you find?
 
 **Solution**
 
@@ -126,6 +126,6 @@ Which can be summarized:
 
 When the size of `prime` is 10 times larger, `prime?` require 3 times more computation.
 
-When the size of  `prime` is 10 times larger, `fast-prime?` require a constant increase of 50µs. ${\mathrm\Theta(\log\;n)}$ growth means that when the prime are ten times larger, the time will increase by a constant amount ${\log(100)-\log(10)=1}$. This is quite clear here.
+When the size of  `prime` is 10 times larger, `fast-prime?` require a constant increase of 50µs. ${\mathrm\Theta(\log n)}$ growth means that when the prime are ten times larger, the time will increase by a constant amount ${\log(100)-\log(10)=1}$. This is quite clear here.
 
 Although that for smaller number `prime?` is faster, `fast-prime?` become much faster with larger and larger prime.

--- a/content/post/SICP-Solution-Exercise-1-25.md
+++ b/content/post/SICP-Solution-Exercise-1-25.md
@@ -88,7 +88,7 @@ These large numbers are called
 > closely related to the available hardware registers: one or two words only and definitely
 > not N words.
 
-While on hardware, operations like multiplication and remainder on `fixnum` can be seen as $O(1)$, on bignum they have a much slower complexity of $O(N\;\log\left(N\right)\;\log\left(\log\left(N\right)\right)$, assuming algorithm like [Karatsuba algorithm](https://en.wikipedia.org/wiki/Karatsuba_algorithm) that is implemented in DrRacket.
+While on hardware, operations like multiplication and remainder on `fixnum` can be seen as $O(1)$, on bignum they have a much slower complexity of $O(N \log\left(N\right) \log\left(\log\left(N\right)\right)$, assuming algorithm like [Karatsuba algorithm](https://en.wikipedia.org/wiki/Karatsuba_algorithm) that is implemented in DrRacket.
 
 By contrast the original algorithm doesn't try to fully compute the `exp` before computing the remainder, but break down the problem intod smaller numbers of roughly the same size:
 

--- a/content/post/SICP-Solution-Exercise-1-26.md
+++ b/content/post/SICP-Solution-Exercise-1-26.md
@@ -22,7 +22,7 @@ type: posts
           m))))
 ```
 
-“I don’t see what difference that could make,” says Louis. “I do.” says Eva. “By writing the procedure like that, you have transformed the ${\mathrm\Theta(\log\;n)}$ process into a ${\mathrm\Theta(n)}$ process.” Explain.
+“I don’t see what difference that could make,” says Louis. “I do.” says Eva. “By writing the procedure like that, you have transformed the ${\mathrm\Theta(\log n)}$ process into a ${\mathrm\Theta(n)}$ process.” Explain.
 
 **Solution**
 
@@ -30,4 +30,4 @@ Louis Reasoner version of `expmod` doesn't user a `square` function, but use a `
 
 In case of `(square (expmod base (/ exp 2) m))`, the parameter of `square` will be evaluated once, then `square` will be applied.
 
-In the case of `(* (expmod base (/ exp 2) m) (expmod base (/ exp 2) m))` each of the two parameters of `*` will be fully evaluated before the `*` will be applied. Since both are recursive call, it will double the work to do, whenever this branch is executed. The complexity becomes $\mathrm\Theta(\log\;2^n)=\mathrm\Theta(n\;\log\;2)=\mathrm\Theta(n)$.
+In the case of `(* (expmod base (/ exp 2) m) (expmod base (/ exp 2) m))` each of the two parameters of `*` will be fully evaluated before the `*` will be applied. Since both are recursive call, it will double the work to do, whenever this branch is executed. The complexity becomes $\mathrm\Theta(\log 2^n)=\mathrm\Theta(n \log 2)=\mathrm\Theta(n)$.

--- a/content/post/SICP-Solution-Exercise-1-28.md
+++ b/content/post/SICP-Solution-Exercise-1-28.md
@@ -15,7 +15,7 @@ Let's break it down in pieces.
 
 If we express this in term of [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic), we have a congrence relation:
 
-$$a^{n-1}\equiv1\;(mod\;n)$$
+$$a^{n-1}\equiv1 (mod n)$$
 
 Which will be implemented by updating the function `fermat-test` into:
 

--- a/content/post/SICP-Solution-Exercise-1-29.md
+++ b/content/post/SICP-Solution-Exercise-1-29.md
@@ -15,7 +15,7 @@ where ${h=(b-a)/n}$, for some even integer $n$, and $y_k={f(a+kh)}$. (Increasing
 
 The sum can be rewritten like this:
 
-$$\frac h3(y_0+4(\underbrace{y_1+y_3+y_5+\cdots+y_n-1}\_{odd\;terms})+2(\underbrace{y_2+y_4+y_6+\cdots+y\_{n-2}}\_{even\;terms})+y_n)$$
+$$\frac h3(y_0+4(\underbrace{y_1+y_3+y_5+\cdots+y_n-1}\_{odd terms})+2(\underbrace{y_2+y_4+y_6+\cdots+y\_{n-2}}\_{even terms})+y_n)$$
 
 This equation can be implemented in a manner that reuse the `sum` function that was defined previously like this:
 

--- a/content/post/SICP-Solution-Exercise-1-39.md
+++ b/content/post/SICP-Solution-Exercise-1-39.md
@@ -7,7 +7,7 @@ type: posts
 
 **Exercise 1.39:** A continued fraction representation of the tangent function was published in 1770 by the German mathematician J.H. Lambert:
 
-$$\tan\;x=\frac x{1-{\displaystyle\frac{x^2}{3-{\displaystyle\frac{x^2}{5-\cdots}}}}}$$
+$$\tan x=\frac x{1-{\displaystyle\frac{x^2}{3-{\displaystyle\frac{x^2}{5-\cdots}}}}}$$
 
 where `x` is in radians. Define a procedure `(tan-cf x k)` that computes an approximation to the tangent function based on Lambert’s formula. `k` specifies the number of terms to compute, as in Exercise 1.37.
 

--- a/content/post/SICP-Solution-Exercise-2-3.md
+++ b/content/post/SICP-Solution-Exercise-2-3.md
@@ -100,7 +100,7 @@ Area 20.0
 
 ## Second representation
 
-Another representation can be specifying three corners out of the four. This representation has 6 degrees of freedom (2 dimensions of each points). It means that it could also represent losange shape. We need to add a constraints so that the angle $\widehat{p1\;p2\;p3}$ is a right angle. Here is what it looks like:
+Another representation can be specifying three corners out of the four. This representation has 6 degrees of freedom (2 dimensions of each points). It means that it could also represent losange shape. We need to add a constraints so that the angle $\widehat{p1 p2 p3}$ is a right angle. Here is what it looks like:
 
 ![Example image](/post/sicp-images/SICP-2_3_-_Google_Slides-2.png)
 


### PR DESCRIPTION
7b64d4730d52c845aed1e047cede89f69ee2bf17 - I noticed some unexpected semicolons `\;` in some LaTEX formulas. I have to assume they were added accidentally somehow, and I chose to replace them with spaces. I found the problematic files with `grep -RlP '\$.*?\\;.*?\$'`, though this regex is not suitable for sed substitution as it can only identify one semicolon within a LaTEX expression at a time.

57886f280c2fbb75d8e88c501142616a4b98f7c7 - issue #4 identified some incorrect references in 1.14 to dimes when nickels and pennies were meant.

I'm getting my feet wet with PRs, let me know if I could have done anything better.