### PR TITLE
Update sicp-solution-exercise-1-38.md

### DIFF
--- a/content/post/sicp-solution-exercise-1-38.md
+++ b/content/post/sicp-solution-exercise-1-38.md
@@ -22,7 +22,7 @@ The key to this exercise is writing a function that will return successively 1, 
     (display (f i)) (display ", ")
     (if (= i n)
         (newline)
-        (rec (add1 i))))
+        (rec (+ i 1))))
   (rec 1))
 
 (display-serie d-euler 12)
@@ -36,7 +36,7 @@ which evaluates to:
 
 The regular grouping of 3 indicates a `modulo 3` going on. Let's try to add it:
 
-```
+```scheme
 (define (d-euler i)
   (if (= (modulo i 3) 2)
       9
@@ -64,39 +64,28 @@ and we evaluate it:
 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, 1,
 ```
 
-Finally, we can put all together and have an approximation for $e$:
+Finally, we can put all together to get an approximation of $e$ (accurate to 4 decimal places when k = 8):
 
 ```scheme
 (define (cont-frac-iter n d k)
   (define (iter i result)
     (if (= 0 i)
         result
-        (iter (sub1 i) (/ (n i) (+ result (d i))))))
-  (iter (sub1 k) (/ (n k) (d k))))
+        (iter (- i 1) (/ (n i) (+ result (d i))))))
+  (iter (- k 1) (/ (n k) (d k))))
 
 (define (d-euler i)
   (if (= (modulo i 3) 2)
-      (* 2(/ (+ i 1) 3))
+      (* 2 (/ (+ i 1) 3))
       1))
 
-(define (display-serie f n)
-  (define (rec i)
-    (display (f i)) (display ", ")
-    (if (= i n)
-        (newline)
-        (rec (add1 i))))
-  (rec 1))
-
-(display-serie d-euler 12)
-
-;  exact result is 0.718281828459
-(cont-frac-iter (lambda (i) 1.0)
+(+ 2 (cont-frac-iter (lambda (i) 1.0)
                  d-euler
-                 1)  (newline)
+                 8))
 ```
 
 Which gives:
 
 ```
-0.7182818284590452
+2.718279569892473
 ```


### PR DESCRIPTION
The proposed solution approximates e - 2, whereas the exercise asks for an approximation of e. Changes correct this error, add consistency with general increment and decrement procedures, and add scheme formatting to a code block.