### PR TITLE
Update sicp-solution-exercise-1-31.md

### DIFF
--- a/content/post/sicp-solution-exercise-1-31.md
+++ b/content/post/sicp-solution-exercise-1-31.md
@@ -42,7 +42,7 @@ Again, this is quite straightforward:
 
 The formula presented in the text is not very clear, but a quick search on [wikipedia](https://en.wikipedia.org/wiki/Wallis_product) gives a formula like this:
 
-$$\prod\_{n=1}^\infty\left(\frac{2n}{2n-1}\cdot\frac{2n}{2n+1}\right)$$
+$$\frac{\pi}{2}=\prod\_{n=1}^\infty\left(\frac{2n}{2n-1}\cdot\frac{2n}{2n+1}\right)$$
 
 This formula can be implemented directly using the `product` function:
 
@@ -54,6 +54,9 @@ This formula can be implemented directly using the `product` function:
        (/ (* 2 n)
           (+ (* 2 n) 1))))
   (product term 1.0 inc n))
+
+(define (wallis-pi/4 n)
+  (/ (wallis-product n) 2))
 ```
 
 One can argument that this is not optimized, since `(* 2 n)` is computed multiple times. On the other hand it makes the code much easier to check.


### PR DESCRIPTION
Note: The Wallis product formula converges to π/2, whereas Exercise 1.31 specifically asks for computing π/4, so a final division by 2 is required after the product.