### PR TITLE
Resolve 1.28 open question

### DIFF
--- a/content/post/sicp-solution-exercise-1-28.md
+++ b/content/post/sicp-solution-exercise-1-28.md
@@ -24,7 +24,7 @@ Which will be implemented by updating the function `fermat-test` into:
 ```scheme
 (define (miller-rabin-test n)
   (define (try-it a)
-    (= (expmod-checked a (- n 1) n) 1))
+    (not (= (expmod-checked a (- n 1) n) 0)))
   (try-it (+ 1 (random (- n 1)))))
 ```
 
@@ -68,7 +68,7 @@ Putting all that together so that `expmod-checked` works with our new functions:
 
 (define (miller-rabin-test n)
   (define (try-it a)
-    (= (expmod-checked a (- n 1) n) 1))
+    (not (= (expmod-checked a (- n 1) n) 0)))
   (try-it (+ 1 (random (- n 1)))))
 
 
@@ -99,7 +99,3 @@ pass:    4 is not prime
 pass:   99 is not prime
 pass:  561 is not prime
 ```
-
-### Open questions
-
-- Running it without `square-checked` (using normal `square`) didn't change the passing of these specific tests. How can we check that we have a correct implementation?


### PR DESCRIPTION
There is an Open Question in 1.28:

> Running it without square-checked (using normal square) didn’t change the passing of these specific tests. How can we check that we have a correct implementation?

I think the reason is that the procedure is not truly using the signal `0` result anywhere. Look at:

```racket
(define (miller-rabin-test n)
  (define (try-it a)
    (= (expmod-checked a (- n 1) n) 1))
  (try-it (+ 1 (random (- n 1)))))
```

^ it's performing almost the same check as the regular fermat-test.

Instead, I think we should be doing:
```racket
(define (miller-rabin-test n)
  (define (try-it a)
    (not = (expmod-checked a (- n 1) n) 0)))
  (try-it (+ 1 (random (- n 1)))))
```

^ that performs the actual check that there is no non-trivial-square-root-of-1.

This is something I discovered while writing my own code, as I fell into the same trap the first time.

---

Btw, thank you for posting your solutions! I am using them as a reference to validate mine.
